### PR TITLE
Adding the "state" param to auth code url requests

### DIFF
--- a/pyfb/client.py
+++ b/pyfb/client.py
@@ -100,7 +100,7 @@ class FacebookClient(object):
         }
         return self._get_auth_url(params, redirect_uri)
 
-    def get_auth_code_url(self, redirect_uri):
+    def get_auth_code_url(self, redirect_uri, state=None):
         """
             Returns the url to get a authentication code
         """
@@ -108,6 +108,10 @@ class FacebookClient(object):
             "client_id": self.app_id,
             "scope": self._get_permissions(),
         }
+
+        if state:
+            params['state'] = state
+
         return self._get_auth_url(params, redirect_uri)
 
     def get_access_token(self, app_secret_key, secret_code, redirect_uri):

--- a/pyfb/pyfb.py
+++ b/pyfb/pyfb.py
@@ -35,11 +35,11 @@ class Pyfb(object):
         """
         return self._client.get_auth_token_url(redirect_uri)
 
-    def get_auth_code_url(self, redirect_uri=None):
+    def get_auth_code_url(self, redirect_uri=None, state=None):
         """
             Returns the url to get a authentication code
         """
-        return self._client.get_auth_code_url(redirect_uri)
+        return self._client.get_auth_code_url(redirect_uri, state=state)
 
     def get_access_token(self, app_secret_key, secret_code, redirect_uri=None):
         """


### PR DESCRIPTION
The Facebook auth code URL allows you to include a "state" parameter which is passed back with your redirect_uri. Useful for passing data for verification of the source and/or needed by the handler page.
